### PR TITLE
Point usb_cam arguments in launch file to correct values

### DIFF
--- a/launch/ar_track_usb_cam.launch
+++ b/launch/ar_track_usb_cam.launch
@@ -1,10 +1,11 @@
 <launch>
-	<arg name="marker_size" default="5.7" />
+	<arg name="marker_size" default="5.0" />
 	<arg name="max_new_marker_error" default="0.08" />
 	<arg name="max_track_error" default="0.2" />
-	<arg name="cam_image_topic" default="/usb_cam/camera_info" />
-	<arg name="cam_info_topic" default="/usb_cam/image_raw" />
-	<arg name="output_frame" default="optical_frame" />
+	
+	<arg name="cam_image_topic" default="/usb_cam/image_raw" />
+	<arg name="cam_info_topic" default="/usb_cam/camera_info" />
+	<arg name="output_frame" default="usb_cam" />
 
 	<node name="ar_track_alvar" pkg="ar_track_alvar" type="individualMarkersNoKinect" respawn="false" output="screen">
 		<param name="marker_size"           type="double" value="$(arg marker_size)" />


### PR DESCRIPTION
The image and info topics have incorrect default values causing the node to spit md5 hash errors. This PR fixes it.